### PR TITLE
Use clang driver when targeting on *-musl-repo

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -1,10 +1,6 @@
-MUSL = /usr/local/musl
-# TODO: the target should be musl rather than gnu.
-CFLAGS =                                 \
-	-target x86_64-pc-linux-gnu-repo \
-	-O0                              \
-	-nostdinc                        \
-	-isystem $(MUSL)/include
+CFLAGS =                                  \
+	-target x86_64-pc-linux-musl-repo \
+	-O0
 
 .PHONY: all
 all:
@@ -24,7 +20,5 @@ distclean: clean
 clang.db: /usr/lib/stdlib.repo
 	cp $< $@
 
-CRTI = $(MUSL)/lib/crt1.t $(MUSL)/lib/crt1_asm.t
-
 a.out: main.o
-	rld -o $@ $(CRTI) main.o $(MUSL)/lib/libc_repo.a
+	$(CC) -o $@ -target x86_64-pc-linux-musl-repo main.o

--- a/cxx/Makefile
+++ b/cxx/Makefile
@@ -9,13 +9,10 @@ MUSL = /usr/local/musl
 
 CXX = c++
 CXXFLAGS = \
-	-target x86_64-pc-linux-gnu-repo \
-	-fno-exceptions                  \
-	-fno-rtti                        \
-	-O0                              \
-	-nostdinc                        \
-	-isystem /usr/include/c++/v1     \
-	-isystem $(MUSL)/include
+	-target x86_64-pc-linux-musl-repo \
+	-fno-exceptions                   \
+	-fno-rtti                         \
+	-O0
 
 .PHONY: all
 all:
@@ -35,9 +32,5 @@ distclean: clean
 clang.db: /usr/lib/stdlib.repo
 	cp $< $@
 
-CRTBEGIN = /usr/lib/linux/clang_rt.crtbegin-x86_64.o
-CRTEND = /usr/lib/linux/clang_rt.crtend-x86_64.o
-CRT1 = $(MUSL)/lib/crt1.t $(MUSL)/lib/crt1_asm.t
-
 hello: hello.o
-	rld -o $@ $(CRTBEGIN) $(CRT1) $^ $(MUSL)/lib/libc_repo.a /usr/lib/libc++abi.a /usr/lib/libc++.a $(CRTEND)
+	$(CXX) -o $@ -target x86_64-pc-linux-musl-repo $^


### PR DESCRIPTION
This change is related to the[ llvm-project-prepo#PR158](https://github.com/SNSystems/llvm-project-prepo/pull/158).

Once the llvm-project-prepo#PR158 is merged back to the master branch, we could update hello-rld to use the repo driver.